### PR TITLE
NGFW-15206 Introduced MarshallingMode for jabsorb and standard REST

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ test.lib=${webinf}/lib
 app=jabsorb
 
 # The tag / version given to this build
-version=1.2.4
+version=1.2.5
 
 # The name of the project
 app-prefix=${app}-${version}

--- a/src/org/jabsorb/JSONRPCBridge.java
+++ b/src/org/jabsorb/JSONRPCBridge.java
@@ -45,6 +45,8 @@ import org.jabsorb.localarg.LocalArgResolver;
 import org.jabsorb.reflect.ClassAnalyzer;
 import org.jabsorb.reflect.ClassData;
 import org.jabsorb.reflect.MethodKey;
+import org.jabsorb.serializer.APIVersion;
+import org.jabsorb.serializer.MarshallingModeContext;
 import org.jabsorb.serializer.MarshallException;
 import org.jabsorb.serializer.ObjectMatch;
 import org.jabsorb.serializer.Serializer;
@@ -110,7 +112,10 @@ import org.slf4j.LoggerFactory;
  */
 public class JSONRPCBridge
  {
-    public JSONRPCBridge()
+
+     private static final String DEFAULT_API_VERSION = "v1";
+
+     public JSONRPCBridge()
     {
         try {
             ser.registerDefaultSerializers();
@@ -518,6 +523,7 @@ public class JSONRPCBridge
 
     String className = null;
     String methodName = null;
+    String apiVersion = null;
     int objectID = 0;
 
     // Parse the class and methodName
@@ -530,6 +536,12 @@ public class JSONRPCBridge
     {
       methodName = t.nextToken();
     }
+    if (t.hasMoreElements()) {
+        apiVersion = t.nextToken();
+    }
+
+    // defaults to v1
+    if (apiVersion == null) apiVersion = DEFAULT_API_VERSION;
 
     // See if we have an object method in the format ".obj#<objectID>"
     if (encodedMethod.startsWith(".obj#"))
@@ -654,16 +666,18 @@ public class JSONRPCBridge
             + method.getName() + "(" + argSignature(method) + ")");
       }
 
+      // Set the marshalling mode based on API version
+      MarshallingModeContext.push(APIVersion.getMarshallingMode(apiVersion));
+
       // Unmarshall arguments
-      Object javaArgs[] = unmarshallArgs(context, method, arguments);
+      Object[] javaArgs = unmarshallArgs(context, method, arguments);
 
       // Call pre invoke callbacks
       if (cbc != null)
       {
-        for (int i = 0; i < context.length; i++)
-        {
-          cbc.preInvokeCallback(context[i], itsThis, method, javaArgs);
-        }
+          for (Object o : context) {
+              cbc.preInvokeCallback(o, itsThis, method, javaArgs);
+          }
       }
 
       // Invoke the method
@@ -672,10 +686,9 @@ public class JSONRPCBridge
       // Call post invoke callbacks
       if (cbc != null)
       {
-        for (int i = 0; i < context.length; i++)
-        {
-          cbc.postInvokeCallback(context[i], itsThis, method, returnObj);
-        }
+          for (Object o : context) {
+              cbc.postInvokeCallback(o, itsThis, method, returnObj);
+          }
       }
 
       // Marshall the result
@@ -696,7 +709,7 @@ public class JSONRPCBridge
           cbc.errorCallback(context[i], itsThis, method, e);
         }
       }
-      log.error("exception occured",e);
+      log.error("exception occurred",e);
       for ( Throwable cause = e.getCause() ; cause != null ; cause = cause.getCause() ) {
         log.error("exception cause: ", cause);
       }
@@ -738,6 +751,8 @@ public class JSONRPCBridge
       }
       result = new JSONRPCResult(JSONRPCResult.CODE_REMOTE_EXCEPTION,
           requestId, exceptionTransformer.transform(e));
+    } finally {
+        MarshallingModeContext.pop();
     }
 
     // Return the results

--- a/src/org/jabsorb/serializer/APIVersion.java
+++ b/src/org/jabsorb/serializer/APIVersion.java
@@ -1,0 +1,42 @@
+package org.jabsorb.serializer;
+
+/**
+ * API version enum and its mapping with the marshalling modes
+ * v1 -> JABSORB
+ * v2 -> STANDARD_REST
+ */
+public enum APIVersion {
+    V1("v1", MarshallingMode.JABSORB),
+    V2("v2", MarshallingMode.STANDARD_REST);
+
+    private final String versionString;
+    private final MarshallingMode marshallingMode;
+
+    APIVersion(String versionString, MarshallingMode marshallingMode) {
+        this.versionString = versionString;
+        this.marshallingMode = marshallingMode;
+    }
+
+    public MarshallingMode getMarshallingMode() {
+        return marshallingMode;
+    }
+
+    public static APIVersion fromString(String value) {
+        for (APIVersion version : values()) {
+            if (version.versionString.equalsIgnoreCase(value)) {
+                return version;
+            }
+        }
+        throw new IllegalArgumentException("Unknown API version: " + value);
+    }
+
+    /**
+     * Returns mapped MarshallingMode for the given API version value.
+     * Throws IllegalArgumentException if API version value is unknown.
+     * @param versionValue
+     * @return
+     */
+    public static MarshallingMode getMarshallingMode(String versionValue) {
+        return fromString(versionValue).getMarshallingMode();
+    }
+}

--- a/src/org/jabsorb/serializer/AbstractSerializer.java
+++ b/src/org/jabsorb/serializer/AbstractSerializer.java
@@ -27,6 +27,8 @@
 package org.jabsorb.serializer;
 
 import org.jabsorb.JSONSerializer;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Convenience class for implementing Serializers providing default setOwner and
@@ -91,5 +93,25 @@ public abstract class AbstractSerializer implements Serializer
   public void setOwner(JSONSerializer ser)
   {
     this.ser = ser;
+  }
+
+  /**
+   * Sets javaClass attribute to JSONObject. javaClass value is retrieved from class name of input Object instance
+   * @param o
+   * @param obj
+   * @throws MarshallException
+   */
+  protected void setJavaClassToJSONObject(Object o, JSONObject obj) throws MarshallException {
+    if (ser.getMarshallClassHints())
+    {
+      try
+      {
+        obj.put("javaClass", o.getClass().getName());
+      }
+      catch (JSONException e)
+      {
+        throw new MarshallException("javaClass not found!");
+      }
+    }
   }
 }

--- a/src/org/jabsorb/serializer/MarshallingMode.java
+++ b/src/org/jabsorb/serializer/MarshallingMode.java
@@ -1,0 +1,11 @@
+package org.jabsorb.serializer;
+
+/**
+ * MarshallingMode enum
+ * JABSORB -> legacy jabsorb styled marshall/unmarshall where nodes like 'list', 'set', 'map' are honoured.
+ * STANDARD_REST -> plain REST styled marshall/unmarshall where no additional nodes are honoured apart from the object structure.
+ */
+public enum MarshallingMode {
+    JABSORB,
+    STANDARD_REST;
+}

--- a/src/org/jabsorb/serializer/MarshallingModeContext.java
+++ b/src/org/jabsorb/serializer/MarshallingModeContext.java
@@ -1,0 +1,47 @@
+package org.jabsorb.serializer;
+
+import java.util.Deque;
+import java.util.Stack;
+import java.util.ArrayDeque;
+
+/**
+ * Context that holds the marshalling mode for a given thread.
+ * Based on the mode, different behavior of marshall/unmarshall can be controlled.
+ */
+public class MarshallingModeContext {
+
+    // Main context (inheritable across child threads)
+    private static final InheritableThreadLocal<Deque<MarshallingMode>> current = new InheritableThreadLocal<Deque<MarshallingMode>>() {
+        @Override
+        protected Deque<MarshallingMode> initialValue() {
+            return new ArrayDeque<>();
+        }
+    };
+
+    /**
+     * Pushes the value on to the stack
+     * @param mode
+     */
+    public static void push(MarshallingMode mode) {
+        current.get().push(mode);
+    }
+
+    /**
+     * peeks the current MarshallingMode value from the stack
+     * @return
+     */
+    public static MarshallingMode get() {
+        Deque<MarshallingMode> stack = current.get();
+        return stack.isEmpty() ? null : stack.peek();
+    }
+
+    /**
+     * pops out the value from the stack
+     */
+    public static void pop() {
+        Deque<MarshallingMode> stack = current.get();
+        if (!stack.isEmpty()) {
+            stack.pop();
+        }
+    }
+}

--- a/src/org/jabsorb/serializer/impl/ListSerializer.java
+++ b/src/org/jabsorb/serializer/impl/ListSerializer.java
@@ -28,12 +28,12 @@ package org.jabsorb.serializer.impl;
 
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
 
 import org.jabsorb.JSONSerializer;
+import org.jabsorb.serializer.MarshallingModeContext;
 import org.jabsorb.serializer.AbstractSerializer;
 import org.jabsorb.serializer.MarshallException;
 import org.jabsorb.serializer.ObjectMatch;
@@ -65,12 +65,14 @@ public class ListSerializer extends AbstractSerializer
   /**
    * Classes that this can serialise to.
    */
-  private static Class[] _JSONClasses = new Class[] { JSONObject.class };
+  private static Class[] _JSONClasses = new Class[] { JSONObject.class, JSONArray.class };
 
   public boolean canSerialize(Class clazz, Class jsonClazz)
   {
-    return (super.canSerialize(clazz, jsonClazz) || ((jsonClazz == null || jsonClazz == JSONObject.class) && List.class
-        .isAssignableFrom(clazz)));
+    return (super.canSerialize(clazz, jsonClazz) ||
+            ((jsonClazz == null ||
+                    ( jsonClazz == JSONObject.class || jsonClazz == JSONArray.class))
+                    && List.class.isAssignableFrom(clazz)));
   }
 
   public Class[] getJSONClasses()
@@ -86,45 +88,78 @@ public class ListSerializer extends AbstractSerializer
   public Object marshall(SerializerState state, Object p, Object o)
       throws MarshallException
   {
-    List list = (List) o;
+    // marshall as per the mode
+    switch (MarshallingModeContext.get()) {
+      case JABSORB:
+        return marshallJabsorb(state, o);
+      case STANDARD_REST:
+        return marshallREST(state, o);
+      default:
+        throw new MarshallException("Invalid marshall mode: " + MarshallingModeContext.get());
+    }
+  }
+
+  /**
+   * Marshall as per jabsorb convention
+   * @param state
+   * @param o
+   * @return
+   * @throws MarshallException
+   */
+  public Object marshallJabsorb(SerializerState state, Object o)
+          throws MarshallException
+  {
     JSONObject obj = new JSONObject();
     JSONArray arr = new JSONArray();
-
-    // TODO: this same block is done everywhere.
-    // Have a single function to do it.
-    if (ser.getMarshallClassHints())
-    {
-      try
-      {
-        obj.put("javaClass", o.getClass().getName());
-      }
-      catch (JSONException e)
-      {
-        throw new MarshallException("javaClass not found!");
-      }
-    }
+    setJavaClassToJSONObject(o, obj);
     try
     {
       obj.put("list", arr);
-      state.push(o, arr, "list");
     }
     catch (JSONException e)
     {
       throw new MarshallException("Error setting list: " + e);
     }
     int index = 0;
-    try
-    {
-      Iterator i = list.iterator();
-      while (i.hasNext())
-      {
-        Object json = ser.marshall(state, arr, i.next(), new Integer(index));
-        if (JSONSerializer.CIRC_REF_OR_DUPLICATE != json)
-        {
+    marshallListToJSONArray(state, o, arr, index, "list");
+    return obj;
+  }
+
+  /**
+   * Marshall as per standard REST convention
+   * @param state
+   * @param o
+   * @return
+   * @throws MarshallException
+   */
+  public Object marshallREST(SerializerState state, Object o)
+          throws MarshallException
+  {
+    JSONArray arr = new JSONArray();
+    int index = 0;
+    marshallListToJSONArray(state, o, arr, index, null);
+    return arr;
+  }
+
+  /**
+   * Marshall input list into JSONArray
+   * pushes objects into state under input parentNode, pops state only if parentNode is not null.
+   * @param state
+   * @param o
+   * @param arr
+   * @param index
+   * @param parentNode
+   * @throws MarshallException
+   */
+  private void marshallListToJSONArray(SerializerState state, Object o, JSONArray arr, int index, String parentNode) throws MarshallException {
+    List list = (List) o;
+    state.push(o, arr, parentNode);
+    try {
+      for (Object object : list) {
+        Object json = ser.marshall(state, arr, object, index);
+        if (JSONSerializer.CIRC_REF_OR_DUPLICATE != json) {
           arr.put(json);
-        }
-        else
-        {
+        } else {
           // put a slot where the object would go, so it can be fixed up properly in the fix up phase
           arr.put(JSONObject.NULL);
         }
@@ -133,13 +168,14 @@ public class ListSerializer extends AbstractSerializer
     }
     catch (MarshallException e)
     {
-      throw (MarshallException) new MarshallException("element " + index).initCause(e);
+      throw new MarshallException("element " + index, e);
     }
-    finally
-    {
-      state.pop();
+    finally {
+      // pop can only be done if state.push() was done against a parent ref
+      if (parentNode != null) {
+        state.pop();
+      }
     }
-    return obj;
   }
 
   // TODO: try unMarshall and unMarshall share 90% code. Put in into an
@@ -149,41 +185,21 @@ public class ListSerializer extends AbstractSerializer
   public ObjectMatch tryUnmarshall(SerializerState state, Class clazz, Object o)
       throws UnmarshallException
   {
-    JSONObject jso = (JSONObject) o;
-    String java_class;
-    try
-    {
-      java_class = jso.getString("javaClass");
+    JSONArray jsonlist = null;
+
+    // unmarshall as per the mode
+    switch (MarshallingModeContext.get()) {
+      case JABSORB:
+        sanityCheckForListClass((JSONObject) o);
+        jsonlist = getJsonArrayFromListNode(o);
+        break;
+      case STANDARD_REST:
+        jsonlist = (JSONArray) o;
+        break;
+      default:
+        throw new UnmarshallException("Invalid unmarshall mode: " + MarshallingModeContext.get());
     }
-    catch (JSONException e)
-    {
-      throw new UnmarshallException("Could not read javaClass", e);
-    }
-    if (java_class == null)
-    {
-      throw new UnmarshallException("no type hint");
-    }
-    if (!(java_class.equals("java.util.List")
-        || java_class.equals("java.util.AbstractList")
-        || java_class.equals("java.util.LinkedList")
-        || java_class.equals("java.util.ArrayList") || java_class
-        .equals("java.util.Vector")))
-    {
-      throw new UnmarshallException("not a List");
-    }
-    JSONArray jsonlist;
-    try
-    {
-      jsonlist = jso.getJSONArray("list");
-    }
-    catch (JSONException e)
-    {
-      throw new UnmarshallException("Could not read list: " + e.getMessage(), e);
-    }
-    if (jsonlist == null)
-    {
-      throw new UnmarshallException("list missing");
-    }
+
     int i = 0;
     ObjectMatch m = new ObjectMatch(-1);
     state.setSerialized(o, m);
@@ -208,54 +224,32 @@ public class ListSerializer extends AbstractSerializer
   public Object unmarshall(SerializerState state, Class clazz, Object o)
       throws UnmarshallException
   {
-    JSONObject jso = (JSONObject) o;
-    String java_class;
-    try
-    {
-      java_class = jso.getString("javaClass");
+    JSONArray jsonlist = null;
+    AbstractList al = null;
+
+    // unmarshall as per the mode
+    switch (MarshallingModeContext.get()) {
+      case JABSORB:
+        sanityCheckForListClass((JSONObject) o);
+        al = getAbstractListByClass(getJavaClass((JSONObject) o));
+        jsonlist = getJsonArrayFromListNode(o);
+        break;
+      case STANDARD_REST:
+        // rely on input clazz to get the list class type
+        if (clazz != null)
+          al = getAbstractListByClass(clazz.getName());
+        jsonlist = (JSONArray) o;
+        break;
+      default:
+        throw new UnmarshallException("Invalid Marshall strategy: " + MarshallingModeContext.get());
     }
-    catch (JSONException e)
-    {
-      throw new UnmarshallException("Could not read javaClass", e);
-    }
-    if (java_class == null)
-    {
-      throw new UnmarshallException("no type hint");
-    }
-    AbstractList al;
-    if (java_class.equals("java.util.List")
-        || java_class.equals("java.util.AbstractList")
-        || java_class.equals("java.util.ArrayList"))
-    {
-      al = new ArrayList();
-    }
-    else if (java_class.equals("java.util.LinkedList"))
-    {
-      al = new LinkedList();
-    }
-    else if (java_class.equals("java.util.Vector"))
-    {
-      al = new Vector();
-    }
-    else
-    {
+
+    if (al == null) {
       throw new UnmarshallException("not a List");
     }
 
-    JSONArray jsonlist;
-    try
-    {
-      jsonlist = jso.getJSONArray("list");
-    }
-    catch (JSONException e)
-    {
-      throw new UnmarshallException("Could not read list: " + e.getMessage(), e);
-    }
-    if (jsonlist == null)
-    {
-      throw new UnmarshallException("list missing");
-    }
     state.setSerialized(o, al);
+
     int i = 0;
     try
     {
@@ -273,6 +267,70 @@ public class ListSerializer extends AbstractSerializer
       throw new UnmarshallException("element " + i + " " + e.getMessage(), e);
     }
     return al;
+  }
+
+  private static AbstractList getAbstractListByClass(String javaClass) throws UnmarshallException {
+    AbstractList al;
+    if (javaClass.equals("java.util.List")
+            || javaClass.equals("java.util.AbstractList")
+            || javaClass.equals("java.util.ArrayList")) {
+      al = new ArrayList();
+    } else if (javaClass.equals("java.util.LinkedList")) {
+      al = new LinkedList();
+    } else if (javaClass.equals("java.util.Vector")) {
+      al = new Vector();
+    } else {
+      throw new UnmarshallException("not a List");
+    }
+    return al;
+  }
+
+  private static JSONArray getJsonArrayFromListNode(Object o) throws UnmarshallException {
+    JSONObject jso = (JSONObject) o;
+
+    JSONArray jsonlist;
+    try
+    {
+      jsonlist = jso.getJSONArray("list");
+    }
+    catch (JSONException e)
+    {
+      throw new UnmarshallException("Could not read list: " + e.getMessage(), e);
+    }
+    if (jsonlist == null)
+    {
+      throw new UnmarshallException("list missing");
+    }
+    return jsonlist;
+  }
+
+  private static String getJavaClass(JSONObject jso) throws UnmarshallException {
+    String javaClass;
+    try
+    {
+      javaClass = jso.getString("javaClass");
+    }
+    catch (JSONException e)
+    {
+      throw new UnmarshallException("Could not read javaClass", e);
+    }
+    if (javaClass == null)
+    {
+      throw new UnmarshallException("no type hint");
+    }
+    return javaClass;
+  }
+
+  private static void sanityCheckForListClass(JSONObject obj) throws UnmarshallException {
+    String javaClass = getJavaClass(obj);
+    if (!(javaClass.equals("java.util.List")
+            || javaClass.equals("java.util.AbstractList")
+            || javaClass.equals("java.util.LinkedList")
+            || javaClass.equals("java.util.ArrayList") || javaClass
+            .equals("java.util.Vector")))
+    {
+      throw new UnmarshallException("not a List");
+    }
   }
 
 }


### PR DESCRIPTION
-  Introduced MarshallingMode which instructs whether to marshall/unmarshall as per jabsorb or standard REST style.
- ListSerializer now support standard REST marshalling, i.e. it does not add/read `list` node in the list.
- Refactored ListSerializer.
- JSONBridge now expects apiVersion in `method` attribute of API's request body. The API version would be available infront of methodname, for ex., `method: obj#<objId>.<method>.<api_version>`. Defaults to `v1`.
- APIVersion has the mapping of api version against the MarshallingMode.
- v1 -> JABSORB and v2 -> STANDARD_REST