### PR TITLE
NGFW-15204 STANDARD_REST marshalling mode support for Set, Map and Dictionary serializers

### DIFF
--- a/src/org/jabsorb/JSONRPCBridge.java
+++ b/src/org/jabsorb/JSONRPCBridge.java
@@ -1689,7 +1689,7 @@ public class JSONRPCBridge
     }
     catch (UnmarshallException e)
     {
-      throw new UnmarshallException("arg " + (i + 1) + " could not unmarshall", e);
+      throw new UnmarshallException("arg " + (i + 1) + " could not unmarshall. arguments: \n" + arguments.toString(), e);
     }
 
     return javaArgs;

--- a/src/org/jabsorb/serializer/AbstractSerializer.java
+++ b/src/org/jabsorb/serializer/AbstractSerializer.java
@@ -114,4 +114,70 @@ public abstract class AbstractSerializer implements Serializer
       }
     }
   }
+
+  /**
+   * Get javaClass from the input object's hint. If unable to get javaClass from the hint, use input clazz
+   * Throws UnmarshallException if unable to retrieve javaClass
+   * @param jso
+   * @return
+   * @throws UnmarshallException
+   */
+  protected static String getJavaClass(JSONObject jso, Class clazz) throws UnmarshallException {
+    String javaClass = null;
+    try
+    {
+      javaClass = jso.getString("javaClass");
+    }
+    catch (JSONException e)
+    {
+      // try getting javaClass using clazz
+    }
+    if (clazz != null) {
+      javaClass = clazz.getName();
+    }
+
+    if (javaClass == null)
+    {
+      throw new UnmarshallException("no type hint");
+    }
+    return javaClass;
+  }
+
+
+  /**
+   * Returns JSON object as per the MarshallingMode.
+   * JABSORB input obj -> '{objKey: {jso}, javaClass: className}'
+   * STANDARD_REST input obj -> '{jso}' (i.e. return as is jso object)
+   * @param jso
+   * @return
+   * @throws UnmarshallException
+   */
+  protected static JSONObject getJsonObjectByMarshallingMode(JSONObject jso, String objKey) throws UnmarshallException {
+    JSONObject jsonObj;
+    switch (MarshallingModeContext.get()) {
+      case JABSORB:
+        try
+        {
+          jsonObj = jso.getJSONObject(objKey);
+        }
+        catch (JSONException e)
+        {
+          throw new UnmarshallException(objKey + " missing", e);
+        }
+        break;
+      case STANDARD_REST:
+        // jso is the actual object
+        jsonObj = jso;
+        break;
+      default:
+        throw new UnmarshallException("Invalid unarshall mode: " + MarshallingModeContext.get());
+    }
+
+    if (jsonObj == null)
+    {
+      throw new UnmarshallException(objKey + " missing");
+    }
+    return jsonObj;
+  }
+
 }

--- a/src/org/jabsorb/serializer/impl/ListSerializer.java
+++ b/src/org/jabsorb/serializer/impl/ListSerializer.java
@@ -190,7 +190,7 @@ public class ListSerializer extends AbstractSerializer
     // unmarshall as per the mode
     switch (MarshallingModeContext.get()) {
       case JABSORB:
-        sanityCheckForListClass((JSONObject) o);
+        sanityCheckForListClass((JSONObject) o, clazz);
         jsonlist = getJsonArrayFromListNode(o);
         break;
       case STANDARD_REST:
@@ -230,8 +230,8 @@ public class ListSerializer extends AbstractSerializer
     // unmarshall as per the mode
     switch (MarshallingModeContext.get()) {
       case JABSORB:
-        sanityCheckForListClass((JSONObject) o);
-        al = getAbstractListByClass(getJavaClass((JSONObject) o));
+        sanityCheckForListClass((JSONObject) o, clazz);
+        al = getAbstractListByClass(getJavaClass((JSONObject) o, clazz));
         jsonlist = getJsonArrayFromListNode(o);
         break;
       case STANDARD_REST:
@@ -304,25 +304,8 @@ public class ListSerializer extends AbstractSerializer
     return jsonlist;
   }
 
-  private static String getJavaClass(JSONObject jso) throws UnmarshallException {
-    String javaClass;
-    try
-    {
-      javaClass = jso.getString("javaClass");
-    }
-    catch (JSONException e)
-    {
-      throw new UnmarshallException("Could not read javaClass", e);
-    }
-    if (javaClass == null)
-    {
-      throw new UnmarshallException("no type hint");
-    }
-    return javaClass;
-  }
-
-  private static void sanityCheckForListClass(JSONObject obj) throws UnmarshallException {
-    String javaClass = getJavaClass(obj);
+  private static void sanityCheckForListClass(JSONObject obj, Class clazz) throws UnmarshallException {
+    String javaClass = getJavaClass(obj, clazz);
     if (!(javaClass.equals("java.util.List")
             || javaClass.equals("java.util.AbstractList")
             || javaClass.equals("java.util.LinkedList")


### PR DESCRIPTION
- Handling JABSORB and STANDARD_REST marshalling modes for remaining serializers.
- Refactored the code that returns the actual data object during unmarshalling based on the Marshalling mode.